### PR TITLE
Changes from background agent bc-22075d83-fc86-42f8-a4a6-51c41db4f524

### DIFF
--- a/DisappearingFloors.lua
+++ b/DisappearingFloors.lua
@@ -1,0 +1,290 @@
+-- Disappearing Floors System
+-- Place this script in ServerScriptService
+
+local RunService = game:GetService("RunService")
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Configuration
+local MIN_TIME_BETWEEN_DISAPPEAR = 3 -- Minimum seconds between parts disappearing
+local MAX_TIME_BETWEEN_DISAPPEAR = 8 -- Maximum seconds between parts disappearing
+local WARNING_TIME = 2 -- How long the warning phase lasts (color changing)
+local DISAPPEAR_TIME = 3 -- How long the part stays invisible
+local RESPAWN_FADE_TIME = 1 -- How long it takes to fade back in
+
+-- Color sequence for warning (goes through these colors before disappearing)
+local WARNING_COLORS = {
+	BrickColor.new("Lime green"),
+	BrickColor.new("Yellow"),
+	BrickColor.new("Orange"),
+	BrickColor.new("Really red")
+}
+
+-- Hazards flag from server round system
+local hazardsValue = ReplicatedStorage:WaitForChild("HazardsEnabled")
+
+-- Get the Map folder
+local mapFolder = workspace:WaitForChild("Map")
+local parts = {}
+
+-- Function to collect all parts from the Map folder
+local function collectParts()
+	parts = {}
+	for _, child in pairs(mapFolder:GetChildren()) do
+		if child:IsA("BasePart") and child.Name == "Part" then
+			table.insert(parts, child)
+			-- Store original properties (only once when first found)
+			if not child:GetAttribute("OriginalTransparency") then
+				child:SetAttribute("OriginalTransparency", child.Transparency)
+				child:SetAttribute("OriginalColor", child.BrickColor.Name)
+				child:SetAttribute("OriginalMaterial", child.Material.Name)
+				child:SetAttribute("IsDisappearing", false)
+			end
+		end
+	end
+	print("DisappearingFloors: Found", #parts, "parts in Map folder")
+end
+
+-- Initial collection
+collectParts()
+
+-- Re-collect parts if new ones are added
+mapFolder.ChildAdded:Connect(function(child)
+	wait(0.1) -- Small delay to ensure part is fully loaded
+	if child:IsA("BasePart") and child.Name == "Part" then
+		collectParts()
+	end
+end)
+
+mapFolder.ChildRemoved:Connect(function(child)
+	if child:IsA("BasePart") and child.Name == "Part" then
+		collectParts()
+	end
+end)
+
+-- Function to make a part flash warning colors
+local function flashWarning(part)
+	if not part or not part.Parent then return end
+
+	part:SetAttribute("IsDisappearing", true)
+
+	-- Calculate time for each color
+	local timePerColor = WARNING_TIME / #WARNING_COLORS
+
+	-- Go through each warning color
+	for i, color in ipairs(WARNING_COLORS) do
+		if part and part.Parent then
+			-- If hazards turned off mid-warning, abort and reset
+			if not hazardsValue.Value then
+				part:SetAttribute("IsDisappearing", false)
+				return
+			end
+			-- Tween to the warning color
+			local colorTween = TweenService:Create(
+				part,
+				TweenInfo.new(timePerColor / 2, Enum.EasingStyle.Linear),
+				{Color = color.Color}
+			)
+			colorTween:Play()
+
+			-- Also change BrickColor for compatibility
+			part.BrickColor = color
+
+			-- Add a slight glow effect
+			if i == #WARNING_COLORS then
+				-- Last color - make it glow more
+				part.Material = Enum.Material.Neon
+			end
+
+			wait(timePerColor)
+		end
+	end
+end
+
+-- Function to make a part disappear
+local function disappearPart(part)
+	if not part or not part.Parent then return end
+
+	-- Store original properties from attributes
+	local originalTransparency = part:GetAttribute("OriginalTransparency") or 0
+	local originalColor = BrickColor.new(part:GetAttribute("OriginalColor") or "Medium stone grey")
+	local originalMaterialName = part:GetAttribute("OriginalMaterial") or "Plastic"
+	local originalMaterial = Enum.Material[originalMaterialName]
+	local originalCanCollide = part.CanCollide
+
+	-- Create disappear effect with tween (just transparency, no color change)
+	local disappearTween = TweenService:Create(
+		part,
+		TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.Out),
+		{
+			Transparency = 1
+		}
+	)
+
+	disappearTween:Play()
+
+	-- Wait for tween to complete
+	wait(0.5)
+
+	-- Make it non-collidable so players fall through
+	part.CanCollide = false
+
+	-- Keep it invisible for the specified time
+	wait(DISAPPEAR_TIME)
+
+	-- Respawn the part
+	if part and part.Parent then
+		-- Make it collidable again first
+		part.CanCollide = originalCanCollide
+
+		-- IMPORTANT: Reset ALL properties to original BEFORE tweening
+		part.Material = originalMaterial
+		part.BrickColor = originalColor
+		part.Color = originalColor.Color
+
+		-- Create reappear effect (only transparency)
+		local reappearTween = TweenService:Create(
+			part,
+			TweenInfo.new(RESPAWN_FADE_TIME, Enum.EasingStyle.Quad, Enum.EasingDirection.In),
+			{
+				Transparency = originalTransparency
+			}
+		)
+
+		reappearTween:Play()
+
+		-- Mark as no longer disappearing
+		part:SetAttribute("IsDisappearing", false)
+	end
+end
+
+-- Main function to handle a single part disappearing
+local function processPart(part)
+	if not part or not part.Parent then return end
+
+	-- Check if part is already disappearing
+	if part:GetAttribute("IsDisappearing") then
+		return
+	end
+
+	-- Flash warning colors
+	flashWarning(part)
+
+	-- If hazards were disabled during the warning, stop here
+	if not hazardsValue.Value then
+		return
+	end
+
+	-- Make it disappear
+	disappearPart(part)
+end
+
+-- Function to randomly select and disappear a part
+local function selectAndDisappearPart()
+	if #parts == 0 then
+		warn("DisappearingFloors: No parts found in Map folder")
+		return
+	end
+
+	-- Filter out parts that are already disappearing
+	local availableParts = {}
+	for _, part in ipairs(parts) do
+		if part and part.Parent and not part:GetAttribute("IsDisappearing") then
+			table.insert(availableParts, part)
+		end
+	end
+
+	if #availableParts == 0 then
+		print("DisappearingFloors: All parts are currently disappearing, waiting...")
+		return
+	end
+
+	-- Select a random part
+	local randomIndex = math.random(1, #availableParts)
+	local selectedPart = availableParts[randomIndex]
+
+	print("DisappearingFloors: Making part disappear at position", selectedPart.Position)
+
+	-- Process the part in a new thread so we don't block
+	task.spawn(function()
+		processPart(selectedPart)
+	end)
+end
+
+-- Main loop gated by hazards flag
+task.spawn(function()
+	wait(3) -- Initial delay before starting
+
+	while true do
+		-- Wait until hazards are enabled (during IN_PROGRESS)
+		if not hazardsValue.Value then
+			hazardsValue.Changed:Wait()
+		end
+		if not hazardsValue.Value then
+			-- In case it flipped back immediately
+			task.wait(0.1)
+			continue
+		end
+
+		-- Make a part disappear
+		selectAndDisappearPart()
+
+		-- Wait random time, but break early if hazards turn off
+		local waitTime = math.random(MIN_TIME_BETWEEN_DISAPPEAR, MAX_TIME_BETWEEN_DISAPPEAR)
+		local elapsed = 0
+		while elapsed < waitTime do
+			if not hazardsValue.Value then
+				break
+			end
+			task.wait(0.25)
+			elapsed += 0.25
+		end
+	end
+end)
+
+-- Optional: Multiple parts disappearing at once for harder difficulty
+local HARD_MODE = false -- Set to true for multiple parts disappearing
+local MAX_SIMULTANEOUS = 3 -- Maximum parts that can disappear at once
+
+if HARD_MODE then
+	task.spawn(function()
+		wait(10) -- Wait 10 seconds before starting hard mode
+
+		while true do
+			-- Wait until hazards are enabled
+			if not hazardsValue.Value then
+				hazardsValue.Changed:Wait()
+			end
+			if not hazardsValue.Value then
+				task.wait(0.1)
+				continue
+			end
+
+			local numParts = math.random(1, MAX_SIMULTANEOUS)
+			for i = 1, numParts do
+				if not hazardsValue.Value then break end
+				task.spawn(function()
+					selectAndDisappearPart()
+				end)
+				wait(0.5) -- Small delay between each part
+			end
+
+			local waitTime = math.random(MIN_TIME_BETWEEN_DISAPPEAR * 2, MAX_TIME_BETWEEN_DISAPPEAR * 2)
+			local elapsed = 0
+			while elapsed < waitTime do
+				if not hazardsValue.Value then
+					break
+				end
+				task.wait(0.25)
+				elapsed += 0.25
+			end
+		end
+	end)
+end
+
+print("DisappearingFloors: System initialized!")
+print("DisappearingFloors: Parts will disappear every", MIN_TIME_BETWEEN_DISAPPEAR, "-", MAX_TIME_BETWEEN_DISAPPEAR, "seconds")
+print("DisappearingFloors: Warning time:", WARNING_TIME, "seconds")
+print("DisappearingFloors: Disappear time:", DISAPPEAR_TIME, "seconds")
+

--- a/PushToolLocalScript.lua
+++ b/PushToolLocalScript.lua
@@ -1,0 +1,230 @@
+-- Push Tool LocalScript
+-- Place this as a LocalScript inside the Push tool in StarterPack
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local tool = script.Parent
+local player = Players.LocalPlayer
+
+-- Verify this is actually a tool
+if not tool:IsA("Tool") then
+	warn("[PUSH CLIENT] Script parent is not a Tool! Parent is:", tool.ClassName)
+	return
+end
+
+-- Configuration
+local PUSH_RANGE = 10 -- How far in front the push reaches (studs)
+local PUSH_FORCE = 30 -- Reduced push force for shorter distance
+local COOLDOWN_TIME = 2 -- Cooldown between pushes in seconds
+
+-- Debug mode
+local DEBUG = true -- Set to false to hide debug messages
+
+-- Cooldown tracking
+local lastPushTime = 0
+local canPush = true
+
+-- Wait for character
+local function getCharacter()
+	return player.Character or player.CharacterAdded:Wait()
+end
+
+-- Debug print function
+local function debugPrint(...)
+	if DEBUG then
+		print("[PUSH CLIENT]", ...)
+	end
+end
+
+debugPrint("Push tool LocalScript starting...")
+debugPrint("Tool name:", tool.Name)
+debugPrint("Tool parent:", tool.Parent and tool.Parent.Name or "nil")
+debugPrint("Tool RequiresHandle:", tool.RequiresHandle)
+
+-- Check if tool has a handle
+local handle = tool:FindFirstChild("Handle")
+if handle then
+	debugPrint("Tool has a Handle part")
+else
+	debugPrint("Tool has NO Handle part")
+	if tool.RequiresHandle then
+		warn("[PUSH CLIENT] Tool requires handle but no Handle part found!")
+	end
+end
+
+-- Create or wait for RemoteEvent
+local pushRemote = ReplicatedStorage:FindFirstChild("PushRemote")
+if not pushRemote then
+	debugPrint("RemoteEvent not found, waiting for server to create it...")
+	pushRemote = ReplicatedStorage:WaitForChild("PushRemote", 10)
+	if not pushRemote then
+		warn("[PUSH CLIENT] RemoteEvent not created after 10 seconds!")
+		return
+	end
+end
+
+debugPrint("RemoteEvent found/created successfully")
+
+-- Optional: Create visual push effect
+local function createPushEffect(targetPosition, distance)
+	local character = getCharacter()
+	if not character then return end
+
+	local myRootPart = character:FindFirstChild("HumanoidRootPart")
+	if not myRootPart then return end
+
+	-- Create a visual effect
+	local part = Instance.new("Part")
+	part.Name = "PushEffect"
+	part.Anchored = true
+	part.CanCollide = false
+	part.Size = Vector3.new(0.5, 0.5, distance or PUSH_RANGE)
+	part.Material = Enum.Material.ForceField
+	part.BrickColor = BrickColor.new("Cyan")
+	part.Transparency = 0.5
+	part.CFrame = CFrame.lookAt(myRootPart.Position, targetPosition) * CFrame.new(0, 0, -part.Size.Z/2)
+	part.Parent = workspace
+
+	-- Fade out and remove
+	game:GetService("Debris"):AddItem(part, 0.3)
+
+	-- Fade animation
+	local startTime = tick()
+	game:GetService("RunService").Heartbeat:Connect(function()
+		local elapsed = tick() - startTime
+		if elapsed < 0.3 and part.Parent then
+			part.Transparency = 0.5 + (elapsed / 0.3) * 0.5
+		end
+	end)
+end
+
+-- Function to find the closest player in front
+local function getTargetInFront()
+	local character = getCharacter()
+	if not character then 
+		debugPrint("No character found")
+		return nil, nil 
+	end
+
+	local humanoidRootPart = character:FindFirstChild("HumanoidRootPart")
+	if not humanoidRootPart then 
+		debugPrint("No HumanoidRootPart found")
+		return nil, nil 
+	end
+
+	local closestPlayer = nil
+	local closestDistance = PUSH_RANGE
+
+	-- Check all players
+	for _, otherPlayer in pairs(Players:GetPlayers()) do
+		if otherPlayer ~= player and otherPlayer.Character then
+			local otherRoot = otherPlayer.Character:FindFirstChild("HumanoidRootPart")
+			local otherHumanoid = otherPlayer.Character:FindFirstChild("Humanoid")
+
+			if otherRoot and otherHumanoid and otherHumanoid.Health > 0 then
+				-- Calculate distance
+				local distance = (otherRoot.Position - humanoidRootPart.Position).Magnitude
+
+				-- Calculate if in front
+				local toTarget = (otherRoot.Position - humanoidRootPart.Position).Unit
+				local lookDirection = humanoidRootPart.CFrame.LookVector
+				local dotProduct = toTarget:Dot(lookDirection)
+
+				debugPrint("Checking player:", otherPlayer.Name, "Distance:", distance, "Dot:", dotProduct)
+
+				-- Check if in range and in front (dot product > 0 means in front)
+				if distance <= PUSH_RANGE and dotProduct > 0.3 and distance < closestDistance then
+					closestPlayer = otherPlayer
+					closestDistance = distance
+					debugPrint("Found valid target:", otherPlayer.Name)
+				end
+			end
+		end
+	end
+
+	return closestPlayer, closestDistance
+end
+
+-- Tool activation
+local function onActivated()
+	debugPrint("Tool activated!")
+
+	-- Check cooldown
+	local currentTime = tick()
+	if currentTime - lastPushTime < COOLDOWN_TIME then
+		local timeLeft = COOLDOWN_TIME - (currentTime - lastPushTime)
+		debugPrint("On cooldown! Time left:", string.format("%.1f", timeLeft), "seconds")
+		print("Push on cooldown! Wait", string.format("%.1f", timeLeft), "more seconds")
+		return
+	end
+
+	local character = getCharacter()
+	if not character then
+		debugPrint("No character on activation")
+		return
+	end
+
+	local humanoidRootPart = character:FindFirstChild("HumanoidRootPart")
+	if not humanoidRootPart then
+		debugPrint("No HumanoidRootPart on activation")
+		return
+	end
+
+	-- Find target (now returns both player and distance)
+local targetPlayer, targetDistance = getTargetInFront()
+
+	if targetPlayer then
+		debugPrint("Pushing player:", targetPlayer.Name, "at distance:", targetDistance)
+
+		-- Calculate push direction
+		local targetRoot = targetPlayer.Character.HumanoidRootPart
+		local pushDirection = (targetRoot.Position - humanoidRootPart.Position).Unit
+
+		-- Create visual effect (optional)
+		createPushEffect(targetRoot.Position, targetDistance)
+
+		-- Send to server
+		pushRemote:FireServer(targetPlayer, pushDirection, PUSH_FORCE)
+
+		-- Set cooldown
+		lastPushTime = currentTime
+
+		-- Visual feedback
+		print("Pushed", targetPlayer.Name, "!")
+		print("Cooldown active for", COOLDOWN_TIME, "seconds")
+	else
+		debugPrint("No valid target found in range")
+		print("No player in range to push! (Range:", PUSH_RANGE, "studs)")
+	end
+end
+
+-- Connect events
+tool.Activated:Connect(onActivated)
+
+-- Also try with Equipped/Unequipped for debugging
+tool.Equipped:Connect(function()
+	debugPrint("Tool equipped!")
+end)
+
+tool.Unequipped:Connect(function()
+	debugPrint("Tool unequipped!")
+end)
+
+-- Alternative activation method (mouse click when equipped)
+local mouse = nil
+tool.Equipped:Connect(function(newMouse)
+	mouse = newMouse
+	debugPrint("Mouse connected")
+
+	if mouse then
+		mouse.Button1Down:Connect(function()
+			debugPrint("Mouse clicked while tool equipped!")
+			onActivated()
+		end)
+	end
+end)
+
+debugPrint("Push tool LocalScript loaded successfully!")
+debugPrint("Waiting for tool activation...")
+

--- a/PushToolServerScript.lua
+++ b/PushToolServerScript.lua
@@ -1,0 +1,336 @@
+-- Push Tool Server Script
+-- Place this in ServerScriptService
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Debris = game:GetService("Debris")
+
+-- Configuration
+local RAGDOLL_DURATION = 1.5 -- How long the ragdoll effect lasts
+local MAX_PUSH_DISTANCE = 15 -- Maximum allowed push distance
+local PUSH_COOLDOWN_PER_PLAYER = {} -- Track cooldowns per player
+local USE_RAGDOLL = true -- Use ragdoll physics (set to false for simple push)
+
+-- Debug mode
+local DEBUG = true -- Set to false to hide debug messages
+
+-- Debug print function
+local function debugPrint(...)
+	if DEBUG then
+		print("[PUSH SERVER]", ...)
+	end
+end
+
+debugPrint("Push server script starting...")
+
+-- Create RemoteEvent
+local pushRemote = Instance.new("RemoteEvent")
+pushRemote.Name = "PushRemote"
+pushRemote.Parent = ReplicatedStorage
+
+debugPrint("RemoteEvent created")
+
+-- PROPER RAGDOLL: Safe ragdoll with BallSocketConstraints
+local function ragdollCharacter(character)
+	debugPrint("Starting safe ragdoll for:", character.Name)
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then 
+		debugPrint("No humanoid found!")
+		return 
+	end
+
+	local rootPart = character:FindFirstChild("HumanoidRootPart") or character:FindFirstChild("Torso")
+	if not rootPart then
+		debugPrint("No root part found!")
+		return
+	end
+
+	-- CRITICAL: Prevent death
+	humanoid.RequiresNeck = false
+	humanoid.BreakJointsOnDeath = false
+	local originalHealth = humanoid.Health
+	local originalMaxHealth = humanoid.MaxHealth
+
+	-- Change state to ragdoll (use Ragdoll state if available, otherwise Physics)
+	humanoid.PlatformStand = true
+	if Enum.HumanoidStateType.Ragdoll then
+		humanoid:ChangeState(Enum.HumanoidStateType.Ragdoll)
+	else
+		humanoid:ChangeState(Enum.HumanoidStateType.FallingDown)
+	end
+
+	-- Store joints and create constraints
+	local joints = {}
+	local constraints = {}
+
+	-- Process each Motor6D joint
+	for _, joint in pairs(character:GetDescendants()) do
+		if joint:IsA("Motor6D") then
+			-- Skip RootJoint to keep character together
+			if joint.Name == "RootJoint" then
+				continue
+			end
+
+			-- Store joint info
+			local jointInfo = {
+				joint = joint,
+				part0 = joint.Part0,
+				part1 = joint.Part1,
+				c0 = joint.C0,
+				c1 = joint.C1,
+				enabled = joint.Enabled
+			}
+			table.insert(joints, jointInfo)
+
+			-- Create attachments for BallSocketConstraint
+			local attachment0 = Instance.new("Attachment")
+			attachment0.CFrame = joint.C0
+			attachment0.Parent = joint.Part0
+
+			local attachment1 = Instance.new("Attachment")
+			attachment1.CFrame = joint.C1
+			attachment1.Parent = joint.Part1
+
+			-- Create BallSocketConstraint
+			local ballSocket = Instance.new("BallSocketConstraint")
+			ballSocket.Attachment0 = attachment0
+			ballSocket.Attachment1 = attachment1
+			ballSocket.LimitsEnabled = true
+			ballSocket.TwistLimitsEnabled = true
+			ballSocket.UpperAngle = 45
+			ballSocket.TwistUpperAngle = 45
+			ballSocket.TwistLowerAngle = -45
+			ballSocket.Restitution = 0.5
+			ballSocket.Parent = joint.Parent
+
+			-- Store constraint info for cleanup
+			table.insert(constraints, {
+				constraint = ballSocket,
+				attachment0 = attachment0,
+				attachment1 = attachment1
+			})
+
+			-- Disable the Motor6D (don't destroy it!)
+			joint.Enabled = false
+
+			debugPrint("Created ragdoll constraint for:", joint.Name)
+		end
+	end
+
+	-- Make limbs collidable
+	for _, part in pairs(character:GetDescendants()) do
+		if part:IsA("BasePart") and part ~= rootPart then
+			part.CanCollide = true
+		end
+	end
+
+	-- Continuously protect health
+	local healthProtection = task.spawn(function()
+		while humanoid and humanoid.Parent do
+			humanoid.Health = originalHealth
+			humanoid.MaxHealth = originalMaxHealth
+			task.wait(0.1)
+		end
+	end)
+
+	debugPrint("Ragdoll applied with", #constraints, "constraints")
+
+	-- Return recovery function
+	return function()
+		debugPrint("Recovering from ragdoll:", character.Name)
+
+		if not character.Parent then 
+			debugPrint("Character no longer exists")
+			return 
+		end
+
+		-- Stop health protection
+		task.cancel(healthProtection)
+
+		-- Remove constraints and attachments
+		for _, constraintInfo in pairs(constraints) do
+			if constraintInfo.constraint then
+				constraintInfo.constraint:Destroy()
+			end
+			if constraintInfo.attachment0 then
+				constraintInfo.attachment0:Destroy()
+			end
+			if constraintInfo.attachment1 then
+				constraintInfo.attachment1:Destroy()
+			end
+		end
+
+		-- Re-enable Motor6Ds
+		for _, jointInfo in pairs(joints) do
+			if jointInfo.joint and jointInfo.joint.Parent then
+				jointInfo.joint.Enabled = true
+			end
+		end
+
+		-- Reset limb collision
+		for _, part in pairs(character:GetDescendants()) do
+			if part:IsA("BasePart") and part ~= rootPart then
+				part.CanCollide = false
+			end
+		end
+
+		-- Restore humanoid
+		if humanoid and humanoid.Parent then
+			humanoid.RequiresNeck = true
+			humanoid.BreakJointsOnDeath = true
+			humanoid.PlatformStand = false
+			humanoid:ChangeState(Enum.HumanoidStateType.Running)
+			humanoid.Health = originalHealth
+			humanoid.MaxHealth = originalMaxHealth
+
+			-- Help them stand
+			if rootPart then
+				rootPart.AssemblyLinearVelocity = Vector3.new(0, 10, 0)
+			end
+		end
+
+		debugPrint("Character recovered from ragdoll successfully")
+	end
+end
+
+-- Handle push request
+pushRemote.OnServerEvent:Connect(function(pusher, targetPlayer, direction, force)
+	debugPrint("Push request from:", pusher.Name, "to:", targetPlayer and targetPlayer.Name or "nil")
+
+	-- Check server-side cooldown
+	local currentTime = tick()
+	if PUSH_COOLDOWN_PER_PLAYER[pusher] and currentTime - PUSH_COOLDOWN_PER_PLAYER[pusher] < 2 then
+		debugPrint("Player", pusher.Name, "is on cooldown")
+		return
+	end
+	PUSH_COOLDOWN_PER_PLAYER[pusher] = currentTime
+
+	-- Validate
+	if not pusher.Character then
+		debugPrint("Pusher has no character")
+		return
+	end
+
+	if not targetPlayer or not targetPlayer.Character then
+		debugPrint("Invalid target player or character")
+		return
+	end
+
+	local pusherRoot = pusher.Character:FindFirstChild("HumanoidRootPart")
+	local targetRoot = targetPlayer.Character:FindFirstChild("HumanoidRootPart")
+	local targetHumanoid = targetPlayer.Character:FindFirstChildOfClass("Humanoid")
+
+	if not pusherRoot or not targetRoot or not targetHumanoid then
+		debugPrint("Missing HumanoidRootPart or Humanoid")
+		return
+	end
+
+	-- Check distance
+	local distance = (targetRoot.Position - pusherRoot.Position).Magnitude
+	debugPrint("Push distance:", distance)
+
+	if distance > MAX_PUSH_DISTANCE then
+		debugPrint("Distance too far:", distance, ">", MAX_PUSH_DISTANCE)
+		warn(pusher.Name, "attempted to push from too far!")
+		return
+	end
+
+	-- Check if target is alive (but we won't damage them)
+	if targetHumanoid.Health <= 0 then
+		debugPrint("Target is already dead, can't push")
+		return
+	end
+
+	-- Store health to ensure no damage
+	local originalHealth = targetHumanoid.Health
+
+	debugPrint("Applying push force...")
+
+	-- Apply push force (reduced for shorter distance)
+	local actualForce = math.clamp(force or 30, 10, 40) -- Much lower max force
+	local pushVelocity = (direction + Vector3.new(0, 0.2, 0)).Unit * actualForce -- Less upward force too
+
+	-- Apply push velocity
+	-- Method 1: Using AssemblyLinearVelocity (newer, more reliable)
+	targetRoot.AssemblyLinearVelocity = pushVelocity
+
+	-- Method 2: Using BodyVelocity for controlled push
+	local bodyVelocity = Instance.new("BodyVelocity")
+	bodyVelocity.MaxForce = Vector3.new(2000, 1000, 2000) -- Reduced max force
+	bodyVelocity.Velocity = pushVelocity
+	bodyVelocity.Parent = targetRoot
+
+	-- Remove BodyVelocity quickly for shorter push
+	Debris:AddItem(bodyVelocity, 0.2) -- Shorter duration
+
+	-- Add friction to stop sliding (creates drag effect)
+	task.wait(0.2)
+	if targetRoot and targetRoot.Parent then
+		-- Apply counter-force to stop sliding
+		local dragVelocity = Instance.new("BodyVelocity")
+		dragVelocity.MaxForce = Vector3.new(3000, 0, 3000) -- Only horizontal drag
+		dragVelocity.Velocity = Vector3.new(0, 0, 0) -- Stop movement
+		dragVelocity.Parent = targetRoot
+
+		-- Remove drag after brief moment
+		Debris:AddItem(dragVelocity, 0.3)
+		debugPrint("Applied drag to limit push distance")
+	end
+
+	debugPrint("Push force applied with distance limiting")
+
+	-- Ensure health protection
+	targetHumanoid.Health = originalHealth
+
+	if USE_RAGDOLL then
+		debugPrint("Applying ragdoll physics")
+
+		-- Apply proper ragdoll with BallSocketConstraints
+		local recover = ragdollCharacter(targetPlayer.Character)
+
+		-- Additional health protection during ragdoll
+		local extraProtection = task.spawn(function()
+			local protectionTime = 0
+			while protectionTime < RAGDOLL_DURATION + 1 do
+				if targetHumanoid and targetHumanoid.Parent then
+					if targetHumanoid.Health < originalHealth then
+						targetHumanoid.Health = originalHealth
+						debugPrint("Health protected during ragdoll")
+					end
+				else
+					break
+				end
+				task.wait(0.1)
+				protectionTime = protectionTime + 0.1
+			end
+		end)
+
+		-- Wait for ragdoll duration
+		task.wait(RAGDOLL_DURATION)
+
+		-- Recover from ragdoll
+		if recover then
+			recover()
+		end
+
+		-- Final health check
+		if targetHumanoid and targetHumanoid.Parent then
+			targetHumanoid.Health = originalHealth
+		end
+	else
+		debugPrint("Simple push without ragdoll")
+		-- Just the push, no ragdoll
+		targetHumanoid.Health = originalHealth
+	end
+end)
+
+-- Clean up cooldowns when players leave
+Players.PlayerRemoving:Connect(function(player)
+	PUSH_COOLDOWN_PER_PLAYER[player] = nil
+end)
+
+debugPrint("Push server script loaded successfully!")
+print("Push System Ready! Debug mode is ON - check output for detailed logs")
+print("Push tool: NO DAMAGE, just physics push with ragdoll")
+

--- a/RotatingKillPart.lua
+++ b/RotatingKillPart.lua
@@ -1,0 +1,248 @@
+-- Rotating Kill Part Script
+-- Place this script inside the cylinder part in ServerScriptService or as a child of the part
+
+local part = script.Parent -- The cylinder part this script is attached to
+
+-- Debug: Check if part exists and is valid
+if not part or not part:IsA("BasePart") then
+	warn("RotatingKillPart: Script parent is not a valid part! Make sure this script is a child of the cylinder part.")
+	return
+end
+
+print("RotatingKillPart: Initializing on part:", part.Name)
+
+local TweenService = game:GetService("TweenService")
+local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+-- Hazards flag
+local hazardsValue = ReplicatedStorage:WaitForChild("HazardsEnabled")
+
+-- Configuration
+local MIN_ROTATION_SPEED = 10 -- Starting rotation speed (degrees per second)
+local MAX_ROTATION_SPEED = 200 -- Maximum rotation speed (degrees per second)
+local SPEED_INCREASE_RATE = 5 -- How fast the speed increases per second
+local RESPAWN_TIME = 3 -- Time before player respawns (in seconds)
+
+-- Current rotation speed (starts at minimum)
+local currentRotationSpeed = MIN_ROTATION_SPEED
+
+print("RotatingKillPart: Rotation speed starting at:", currentRotationSpeed, "degrees/second")
+
+-- Set up the part properties
+part.Material = Enum.Material.Neon -- Makes it look dangerous
+part.BrickColor = BrickColor.new("Lime green") -- Starts green (safe/slow)
+part.TopSurface = Enum.SurfaceType.Smooth
+part.BottomSurface = Enum.SurfaceType.Smooth
+part.CanCollide = true
+part.Anchored = true -- Keep it in place while rotating
+
+-- Network ownership can't be set on anchored parts, so we skip it
+-- part:SetNetworkOwner(nil) -- This causes an error with anchored parts
+
+-- Ensure part properties are set correctly
+part.CanCollide = true -- Keep collisions for touch detection
+part.CanTouch = true -- Keep touch events
+part.CanQuery = true -- Keep this true for touch detection to work properly
+
+-- Create a selection box for visual effect (optional)
+local selectionBox = Instance.new("SelectionBox")
+selectionBox.Parent = part
+selectionBox.Adornee = part
+selectionBox.Color3 = Color3.new(1, 0, 0) -- Red outline
+selectionBox.LineThickness = 0.1
+selectionBox.Transparency = 0.5
+
+-- Reset rotation when hazards are disabled
+hazardsValue.Changed:Connect(function()
+	if not hazardsValue.Value then
+		currentRotationSpeed = MIN_ROTATION_SPEED
+		part.BrickColor = BrickColor.new("Lime green")
+	end
+end)
+
+-- Check if we should be active (controlled by round system)
+local isActive = true
+
+-- Rotation using RunService for smooth rotation (EXACTLY like the original script)
+print("RotatingKillPart: Starting rotation loop...")
+
+local connection
+connection = RunService.Heartbeat:Connect(function(deltaTime)
+	-- Check if script is disabled (by round system) or hazards are off
+	if not script.Enabled or not hazardsValue.Value then
+		return -- Skip rotation and damage when disabled or hazards off
+	end
+	-- Increase speed over time (up to maximum)
+	if currentRotationSpeed < MAX_ROTATION_SPEED then
+		currentRotationSpeed = math.min(currentRotationSpeed + (SPEED_INCREASE_RATE * deltaTime), MAX_ROTATION_SPEED)
+
+		-- Change color based on speed (green to red)
+		local speedRatio = (currentRotationSpeed - MIN_ROTATION_SPEED) / (MAX_ROTATION_SPEED - MIN_ROTATION_SPEED)
+		part.Color = Color3.new(speedRatio, 1 - speedRatio, 0) -- Gradual color change from green to red
+	end
+
+	-- Rotate the part on Z axis for horizontal spinning (like a rolling log)
+	-- THIS IS THE EXACT SAME ROTATION METHOD FROM THE ORIGINAL SCRIPT
+	part.CFrame = part.CFrame * CFrame.Angles(0, 0, math.rad(currentRotationSpeed * deltaTime))
+end)
+
+print("RotatingKillPart: Rotation started successfully!")
+
+-- METHOD 2: Alternative using Stepped for physics synchronization (uncomment to use)
+--[[
+local connection
+connection = RunService.Stepped:Connect(function(time, deltaTime)
+	-- Increase speed over time
+	if currentRotationSpeed < MAX_ROTATION_SPEED then
+		currentRotationSpeed = math.min(currentRotationSpeed + (SPEED_INCREASE_RATE * deltaTime), MAX_ROTATION_SPEED)
+
+		local speedRatio = (currentRotationSpeed - MIN_ROTATION_SPEED) / (MAX_ROTATION_SPEED - MIN_ROTATION_SPEED)
+		part.Color = Color3.new(speedRatio, 1 - speedRatio, 0)
+	end
+
+	-- Update angle
+	currentAngle = currentAngle + math.rad(currentRotationSpeed * deltaTime)
+
+	-- Apply rotation with fixed position (X-axis for horizontal spin)
+	part.CFrame = CFrame.new(originalPosition) * CFrame.Angles(currentAngle, 0, 0)
+end)
+--]]
+
+-- METHOD 3: Using BodyPosition + BodyAngularVelocity for physics-based rotation (uncomment to use)
+--[[
+-- Create BodyPosition to lock position
+local bodyPosition = Instance.new("BodyPosition")
+bodyPosition.MaxForce = Vector3.new(math.huge, math.huge, math.huge)
+bodyPosition.Position = originalPosition
+bodyPosition.Parent = part
+
+-- Create BodyAngularVelocity for rotation
+local bodyAngularVelocity = Instance.new("BodyAngularVelocity")
+bodyAngularVelocity.MaxTorque = Vector3.new(math.huge, 0, 0) -- X-axis torque for horizontal spin
+bodyAngularVelocity.AngularVelocity = Vector3.new(math.rad(currentRotationSpeed), 0, 0) -- X-axis rotation
+bodyAngularVelocity.Parent = part
+
+-- Update only the angular velocity
+local connection
+connection = RunService.Heartbeat:Connect(function(deltaTime)
+	if currentRotationSpeed < MAX_ROTATION_SPEED then
+		currentRotationSpeed = math.min(currentRotationSpeed + (SPEED_INCREASE_RATE * deltaTime), MAX_ROTATION_SPEED)
+
+		local speedRatio = (currentRotationSpeed - MIN_ROTATION_SPEED) / (MAX_ROTATION_SPEED - MIN_ROTATION_SPEED)
+		part.Color = Color3.new(speedRatio, 1 - speedRatio, 0)
+
+		-- Update angular velocity (X-axis)
+		bodyAngularVelocity.AngularVelocity = Vector3.new(math.rad(currentRotationSpeed), 0, 0)
+	end
+end)
+--]]
+
+-- Alternative rotation method using TweenService (smoother but less flexible)
+--[[
+local function rotatePart()
+	local tweenInfo = TweenInfo.new(
+		2, -- Duration (2 seconds for full rotation)
+		Enum.EasingStyle.Linear,
+		Enum.EasingDirection.InOut,
+		-1, -- Repeat infinitely
+		false -- Don't reverse
+	)
+
+	local goal = {
+		CFrame = part.CFrame * CFrame.Angles(math.rad(360), 0, 0) -- X-axis rotation for horizontal spin
+	}
+
+	local tween = TweenService:Create(part, tweenInfo, goal)
+	tween:Play()
+end
+rotatePart()
+--]]
+
+-- Kill function with speed reset
+local function killPlayer(character)
+	local humanoid = character:FindFirstChild("Humanoid")
+	if humanoid and humanoid.Health > 0 then
+		-- Set health to 0 to kill the player
+		humanoid.Health = 0
+
+		-- RESET THE ROTATION SPEED BACK TO MINIMUM (smooth reset)
+		currentRotationSpeed = MIN_ROTATION_SPEED
+		part.BrickColor = BrickColor.new("Lime green") -- Visual feedback for reset
+
+		-- Flash effect to show speed reset
+		task.spawn(function()
+			task.wait(0.2)
+			part.BrickColor = BrickColor.new("Really red")
+		end)
+
+		-- Optional: Add death effect
+		local player = game.Players:GetPlayerFromCharacter(character)
+		if player then
+			print(player.Name .. " was killed by the rotating cylinder! Speed reset to minimum.")
+			print("Current rotation speed: " .. currentRotationSpeed .. " degrees/second")
+		end
+	end
+end
+
+-- Debounce table to prevent multiple kills
+local debounce = {}
+
+-- Touch event
+part.Touched:Connect(function(hit)
+	-- Check if script is disabled (by round system) or hazards off
+	if not script.Enabled or not hazardsValue.Value then
+		return -- No damage when disabled or hazards are off
+	end
+	-- Check if the touched object belongs to a player
+	local character = hit.Parent
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+
+	if humanoid then
+		-- Check debounce to prevent multiple triggers
+		if not debounce[character] then
+			debounce[character] = true
+
+			-- Kill the player
+			killPlayer(character)
+
+			-- Reset debounce after a short delay
+			task.wait(1)
+			debounce[character] = nil
+		end
+	end
+end)
+
+-- Optional: Add particle effects for visual enhancement
+local function addParticleEffect()
+	local attachment = Instance.new("Attachment")
+	attachment.Parent = part
+
+	local particleEmitter = Instance.new("ParticleEmitter")
+	particleEmitter.Parent = attachment
+	particleEmitter.Texture = "rbxasset://textures/particles/sparkles_main.dds"
+	particleEmitter.Rate = 50
+	particleEmitter.Lifetime = NumberRange.new(0.5, 1)
+	particleEmitter.VelocityInheritance = 0.5
+	particleEmitter.EmissionDirection = Enum.NormalId.Top
+	particleEmitter.Speed = NumberRange.new(2, 5)
+	particleEmitter.SpreadAngle = Vector2.new(45, 45)
+	particleEmitter.Color = ColorSequence.new(Color3.new(1, 0, 0)) -- Red particles
+	particleEmitter.LightEmission = 1
+	particleEmitter.LightInfluence = 0
+end
+
+-- Add particle effect
+addParticleEffect()
+
+-- Clean up on script removal
+script.AncestryChanged:Connect(function()
+	if not script.Parent then
+		if connection then
+			connection:Disconnect()
+		end
+	end
+end)
+
+print("Rotating Kill Part initialized!")
+

--- a/RoundSystem.lua
+++ b/RoundSystem.lua
@@ -1,0 +1,366 @@
+-- Round System Main Script
+-- Place this in ServerScriptService
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local TweenService = game:GetService("TweenService")
+
+-- Configuration
+local MIN_PLAYERS = 2 -- Minimum players to start
+local INTERMISSION_TIME = 10 -- Seconds for intermission
+local FREEZE_TIME = 3 -- Seconds players are frozen at round start
+local RESPAWN_DELAY = 1 -- Delay before respawning to lobby
+
+-- Game States
+local GameState = {
+	WAITING = "WAITING",
+	INTERMISSION = "INTERMISSION",
+	STARTING = "STARTING",
+	IN_PROGRESS = "IN_PROGRESS",
+	ENDING = "ENDING"
+}
+
+-- Current state
+local currentState = GameState.WAITING
+local playersInRound = {}
+local roundActive = false
+local freezePlayers = false
+
+-- Get spawn locations
+local spawnMap = workspace:WaitForChild("SpawnMap")
+local gameMap = workspace:WaitForChild("Map")
+local lobbySpawns = {}
+local gameSpawns = {}
+
+-- Collect spawn points
+local function collectSpawnPoints()
+	lobbySpawns = {}
+	gameSpawns = {}
+
+	-- Collect lobby spawns
+	for _, spawn in pairs(spawnMap:GetDescendants()) do
+		if spawn:IsA("SpawnLocation") then
+			table.insert(lobbySpawns, spawn)
+			spawn.Enabled = true -- Enable lobby spawns
+		end
+	end
+
+	-- Collect game spawns
+	for _, spawn in pairs(gameMap:GetDescendants()) do
+		if spawn:IsA("SpawnLocation") then
+			table.insert(gameSpawns, spawn)
+			spawn.Enabled = false -- Disable game spawns initially
+		end
+	end
+
+	print("[ROUND SYSTEM] Found", #lobbySpawns, "lobby spawns and", #gameSpawns, "game spawns")
+end
+
+-- Create RemoteEvents for UI
+local remoteEvents = Instance.new("Folder")
+remoteEvents.Name = "RoundEvents"
+remoteEvents.Parent = ReplicatedStorage
+
+local stateChangeRemote = Instance.new("RemoteEvent")
+stateChangeRemote.Name = "StateChange"
+stateChangeRemote.Parent = remoteEvents
+
+local timerRemote = Instance.new("RemoteEvent")
+timerRemote.Name = "TimerUpdate"
+timerRemote.Parent = remoteEvents
+
+-- Global hazards flag for gating map hazards
+local hazardsEnabled = Instance.new("BoolValue")
+hazardsEnabled.Name = "HazardsEnabled"
+hazardsEnabled.Value = false
+hazardsEnabled.Parent = ReplicatedStorage
+
+-- Broadcast state to all clients
+local function broadcastState(state, message)
+	stateChangeRemote:FireAllClients(state, message)
+	print("[ROUND SYSTEM] State:", state, "-", message or "")
+end
+
+-- Broadcast timer to all clients with total time and phase
+local function broadcastTimer(timeLeft, totalTime, phase)
+	timerRemote:FireAllClients(timeLeft, totalTime, phase)
+end
+
+-- Teleport player to spawn
+local function teleportToSpawn(player, spawnList)
+	if not player.Character then return end
+
+	local humanoidRootPart = player.Character:FindFirstChild("HumanoidRootPart")
+	if not humanoidRootPart then return end
+
+	if #spawnList > 0 then
+		local randomSpawn = spawnList[math.random(1, #spawnList)]
+		humanoidRootPart.CFrame = randomSpawn.CFrame + Vector3.new(0, 3, 0)
+	end
+end
+
+-- Freeze/Unfreeze player
+local function setPlayerFreeze(player, frozen)
+	if not player.Character then return end
+
+	local humanoid = player.Character:FindFirstChildOfClass("Humanoid")
+	local rootPart = player.Character:FindFirstChild("HumanoidRootPart")
+
+	if humanoid and rootPart then
+		if frozen then
+			humanoid.WalkSpeed = 0
+			humanoid.JumpPower = 0
+			humanoid.JumpHeight = 0
+			rootPart.Anchored = true
+		else
+			humanoid.WalkSpeed = 16
+			humanoid.JumpPower = 50
+			humanoid.JumpHeight = 7.2
+			rootPart.Anchored = false
+		end
+	end
+end
+
+-- Control kill brick
+local function setKillBrickActive(active)
+	-- Find the rotating kill part
+	local killPart = workspace:FindFirstChild("SpinKiller")
+	if killPart then
+		local script = killPart:FindFirstChildOfClass("Script")
+		if script then
+			script.Enabled = active
+			print("[ROUND SYSTEM] Kill brick", active and "activated" or "deactivated")
+		end
+	end
+end
+
+-- Handle player death
+local function onPlayerDied(player)
+	-- Remove from round
+	for i, p in ipairs(playersInRound) do
+		if p == player then
+			table.remove(playersInRound, i)
+			break
+		end
+	end
+
+	print("[ROUND SYSTEM]", player.Name, "died. Players remaining:", #playersInRound)
+
+	-- Respawn to lobby after delay
+	task.wait(RESPAWN_DELAY)
+	if player.Character then
+		player:LoadCharacter()
+		task.wait(0.5)
+		teleportToSpawn(player, lobbySpawns)
+	end
+
+	-- Check for winner
+	if roundActive and #playersInRound == 1 then
+		-- We have a winner!
+		local winner = playersInRound[1]
+		endRound(winner)
+	elseif roundActive and #playersInRound == 0 then
+		-- No winner (shouldn't happen but safety check)
+		endRound(nil)
+	end
+end
+
+-- Start round
+local function startRound()
+	currentState = GameState.STARTING
+	roundActive = true
+	playersInRound = {}
+
+	print("[ROUND SYSTEM] Starting round...")
+	broadcastState("STARTING", "Round starting!")
+
+	-- Disable hazards during freeze
+	hazardsEnabled.Value = false
+	setKillBrickActive(false)
+
+	-- Disable lobby spawns, enable game spawns
+	for _, spawn in pairs(lobbySpawns) do
+		spawn.Enabled = false
+	end
+	for _, spawn in pairs(gameSpawns) do
+		spawn.Enabled = true
+	end
+
+	-- Teleport all players to game map
+	for _, player in pairs(Players:GetPlayers()) do
+		if player.Character then
+			table.insert(playersInRound, player)
+			teleportToSpawn(player, gameSpawns)
+			setPlayerFreeze(player, true) -- Freeze players
+		end
+	end
+
+	-- Countdown freeze time
+	for i = FREEZE_TIME, 1, -1 do
+		broadcastState("STARTING", "Get ready! " .. i)
+		broadcastTimer(i, FREEZE_TIME, "FREEZE")
+		task.wait(1)
+	end
+
+	-- Unfreeze players and start the round
+	currentState = GameState.IN_PROGRESS
+	broadcastState("IN_PROGRESS", "GO!")
+
+	for _, player in pairs(playersInRound) do
+		setPlayerFreeze(player, false)
+	end
+
+	-- Activate hazards after freeze
+	hazardsEnabled.Value = true
+	setKillBrickActive(true)
+
+	print("[ROUND SYSTEM] Round is now active with", #playersInRound, "players")
+end
+
+-- End round
+function endRound(winner)
+	if not roundActive then return end
+
+	currentState = GameState.ENDING
+	roundActive = false
+
+	-- Deactivate hazards immediately
+	hazardsEnabled.Value = false
+	setKillBrickActive(false)
+
+	if winner then
+		broadcastState("ENDING", winner.Name .. " wins!")
+		print("[ROUND SYSTEM]", winner.Name, "won the round!")
+
+		-- Give reward here if needed
+		-- winner.leaderstats.Wins.Value += 1
+	else
+		broadcastState("ENDING", "Round ended - no winner")
+		print("[ROUND SYSTEM] Round ended with no winner")
+	end
+
+	-- Wait a bit to show winner
+	task.wait(3)
+
+	-- Teleport all players back to lobby
+	for _, player in pairs(Players:GetPlayers()) do
+		if player.Character then
+			player:LoadCharacter()
+			task.wait(0.1)
+			teleportToSpawn(player, lobbySpawns)
+		end
+	end
+
+	-- Re-enable lobby spawns, disable game spawns
+	for _, spawn in pairs(lobbySpawns) do
+		spawn.Enabled = true
+	end
+	for _, spawn in pairs(gameSpawns) do
+		spawn.Enabled = false
+	end
+
+	-- Reset to waiting state
+	currentState = GameState.WAITING
+	playersInRound = {}
+
+	print("[ROUND SYSTEM] Returned to lobby, waiting for players...")
+end
+
+-- Main game loop
+local function gameLoop()
+	while true do
+		local playerCount = #Players:GetPlayers()
+
+		if currentState == GameState.WAITING then
+			if playerCount >= MIN_PLAYERS then
+				-- Start intermission
+				currentState = GameState.INTERMISSION
+				broadcastState("INTERMISSION", "Starting intermission...")
+
+				for i = INTERMISSION_TIME, 1, -1 do
+					broadcastTimer(i, INTERMISSION_TIME, "INTERMISSION")
+					broadcastState("INTERMISSION", "Round starts in " .. i .. " seconds")
+					task.wait(1)
+
+					-- Check if enough players still
+					if #Players:GetPlayers() < MIN_PLAYERS then
+						currentState = GameState.WAITING
+						broadcastState("WAITING", "Not enough players")
+						break
+					end
+				end
+
+				-- Start round if still enough players
+				if currentState == GameState.INTERMISSION and #Players:GetPlayers() >= MIN_PLAYERS then
+					startRound()
+				end
+			else
+				broadcastState("WAITING", "Waiting for players... (" .. playerCount .. "/" .. MIN_PLAYERS .. ")")
+			end
+		end
+
+		task.wait(1)
+	end
+end
+
+-- Player joined
+Players.PlayerAdded:Connect(function(player)
+	print("[ROUND SYSTEM]", player.Name, "joined. Total players:", #Players:GetPlayers())
+
+	-- Set up character spawning
+	player.CharacterAdded:Connect(function(character)
+		local humanoid = character:WaitForChild("Humanoid")
+
+		-- Handle death
+		humanoid.Died:Connect(function()
+			if roundActive then
+				onPlayerDied(player)
+			end
+		end)
+
+		-- Spawn in lobby if not in round
+		if not roundActive then
+			task.wait(0.5)
+			teleportToSpawn(player, lobbySpawns)
+		end
+	end)
+
+	-- Initial spawn
+	player:LoadCharacter()
+end)
+
+-- Player left
+Players.PlayerRemoving:Connect(function(player)
+	print("[ROUND SYSTEM]", player.Name, "left. Total players:", #Players:GetPlayers() - 1)
+
+	-- Remove from round if in it
+	for i, p in ipairs(playersInRound) do
+		if p == player then
+			table.remove(playersInRound, i)
+			break
+		end
+	end
+
+	-- Check if round should end
+	if roundActive and #playersInRound <= 1 then
+		if #playersInRound == 1 then
+			endRound(playersInRound[1])
+		else
+			endRound(nil)
+		end
+	end
+end)
+
+-- Initialize
+collectSpawnPoints()
+
+-- Ensure hazards are disabled at startup
+hazardsEnabled.Value = false
+setKillBrickActive(false)
+
+print("[ROUND SYSTEM] Initialized and waiting for players...")
+
+-- Start game loop
+task.spawn(gameLoop)
+

--- a/RoundUIClient.lua
+++ b/RoundUIClient.lua
@@ -1,0 +1,254 @@
+-- Round System UI Client
+-- Place this as a LocalScript in StarterPlayer > StarterPlayerScripts
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+
+local player = Players.LocalPlayer
+local playerGui = player:WaitForChild("PlayerGui")
+
+-- Wait for RemoteEvents
+local roundEvents = ReplicatedStorage:WaitForChild("RoundEvents")
+local stateChangeRemote = roundEvents:WaitForChild("StateChange")
+local timerRemote = roundEvents:WaitForChild("TimerUpdate")
+
+-- Create UI
+local screenGui = Instance.new("ScreenGui")
+screenGui.Name = "RoundUI"
+screenGui.ResetOnSpawn = false
+screenGui.Parent = playerGui
+
+-- Main frame for status
+local statusFrame = Instance.new("Frame")
+statusFrame.Size = UDim2.new(0.4, 0, 0.15, 0)
+statusFrame.Position = UDim2.new(0.3, 0, 0.05, 0)
+statusFrame.BackgroundColor3 = Color3.new(0, 0, 0)
+statusFrame.BackgroundTransparency = 0.3
+statusFrame.BorderSizePixel = 0
+statusFrame.Parent = screenGui
+
+-- Add rounded corners
+local uiCorner = Instance.new("UICorner")
+uiCorner.CornerRadius = UDim.new(0, 12)
+uiCorner.Parent = statusFrame
+
+-- Add gradient
+local uiGradient = Instance.new("UIGradient")
+uiGradient.Color = ColorSequence.new{
+	ColorSequenceKeypoint.new(0, Color3.new(0.2, 0.2, 0.3)),
+	ColorSequenceKeypoint.new(1, Color3.new(0.1, 0.1, 0.2))
+}
+uiGradient.Rotation = 90
+uiGradient.Parent = statusFrame
+
+-- Status text
+local statusText = Instance.new("TextLabel")
+statusText.Size = UDim2.new(1, 0, 0.5, 0)
+statusText.Position = UDim2.new(0, 0, 0, 0)
+statusText.BackgroundTransparency = 1
+statusText.Text = "Waiting for players..."
+statusText.TextColor3 = Color3.new(1, 1, 1)
+statusText.TextScaled = true
+statusText.Font = Enum.Font.SourceSansBold
+statusText.Parent = statusFrame
+
+-- Timer text
+local timerText = Instance.new("TextLabel")
+timerText.Size = UDim2.new(1, 0, 0.38, 0)
+timerText.Position = UDim2.new(0, 0, 0.5, 0)
+timerText.BackgroundTransparency = 1
+timerText.Text = ""
+timerText.TextColor3 = Color3.new(1, 0.8, 0)
+timerText.TextScaled = true
+timerText.Font = Enum.Font.SourceSans
+timerText.Parent = statusFrame
+
+-- Progress bar
+local progressBack = Instance.new("Frame")
+progressBack.Name = "ProgressBack"
+progressBack.Size = UDim2.new(1, 0, 0.12, 0)
+progressBack.Position = UDim2.new(0, 0, 0.88, 0)
+progressBack.BackgroundColor3 = Color3.fromRGB(25, 25, 35)
+progressBack.BackgroundTransparency = 0.2
+progressBack.BorderSizePixel = 0
+progressBack.Visible = false
+progressBack.Parent = statusFrame
+
+local progressCorner = Instance.new("UICorner")
+progressCorner.CornerRadius = UDim.new(0, 10)
+progressCorner.Parent = progressBack
+
+local progressFill = Instance.new("Frame")
+progressFill.Name = "ProgressFill"
+progressFill.Size = UDim2.new(0, 0, 1, 0)
+progressFill.BackgroundColor3 = Color3.fromRGB(255, 170, 0)
+progressFill.BorderSizePixel = 0
+progressFill.Parent = progressBack
+
+local progressFillCorner = Instance.new("UICorner")
+progressFillCorner.CornerRadius = UDim.new(0, 10)
+progressFillCorner.Parent = progressFill
+
+local progressGradient = Instance.new("UIGradient")
+progressGradient.Color = ColorSequence.new{
+	ColorSequenceKeypoint.new(0, Color3.fromRGB(255, 190, 0)),
+	ColorSequenceKeypoint.new(1, Color3.fromRGB(255, 110, 0))
+}
+progressGradient.Parent = progressFill
+
+-- Winner announcement frame (hidden initially)
+local winnerFrame = Instance.new("Frame")
+winnerFrame.Size = UDim2.new(0.6, 0, 0.3, 0)
+winnerFrame.Position = UDim2.new(0.2, 0, 2, 0) -- Off screen
+winnerFrame.BackgroundColor3 = Color3.new(0.1, 0.1, 0.1)
+winnerFrame.BackgroundTransparency = 0.1
+winnerFrame.BorderSizePixel = 0
+winnerFrame.Parent = screenGui
+
+local winnerCorner = Instance.new("UICorner")
+winnerCorner.CornerRadius = UDim.new(0, 20)
+winnerCorner.Parent = winnerFrame
+
+local winnerGradient = Instance.new("UIGradient")
+winnerGradient.Color = ColorSequence.new{
+	ColorSequenceKeypoint.new(0, Color3.new(1, 0.8, 0)),
+	ColorSequenceKeypoint.new(0.5, Color3.new(1, 0.6, 0)),
+	ColorSequenceKeypoint.new(1, Color3.new(1, 0.4, 0))
+}
+winnerGradient.Rotation = 45
+winnerGradient.Parent = winnerFrame
+
+local winnerText = Instance.new("TextLabel")
+winnerText.Size = UDim2.new(1, 0, 1, 0)
+winnerText.BackgroundTransparency = 1
+winnerText.Text = "WINNER!"
+winnerText.TextColor3 = Color3.new(1, 1, 1)
+winnerText.TextScaled = true
+winnerText.Font = Enum.Font.SourceSansBold
+winnerText.Parent = winnerFrame
+
+-- Countdown frame (for 3-2-1 countdown)
+local countdownFrame = Instance.new("Frame")
+countdownFrame.Size = UDim2.new(0.3, 0, 0.3, 0)
+countdownFrame.Position = UDim2.new(0.35, 0, 2, 0) -- Off screen
+countdownFrame.BackgroundColor3 = Color3.new(0, 0, 0)
+countdownFrame.BackgroundTransparency = 0.5
+countdownFrame.BorderSizePixel = 0
+countdownFrame.Parent = screenGui
+
+local countdownCorner = Instance.new("UICorner")
+countdownCorner.CornerRadius = UDim.new(0.5, 0)
+countdownCorner.Parent = countdownFrame
+
+local countdownText = Instance.new("TextLabel")
+countdownText.Size = UDim2.new(1, 0, 1, 0)
+countdownText.BackgroundTransparency = 1
+countdownText.Text = "3"
+countdownText.TextColor3 = Color3.new(1, 1, 1)
+countdownText.TextScaled = true
+countdownText.Font = Enum.Font.SourceSansBold
+countdownText.Parent = countdownFrame
+
+-- Animation functions
+local function showWinner(text)
+	winnerText.Text = text
+	local tween = TweenService:Create(winnerFrame, TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {
+		Position = UDim2.new(0.2, 0, 0.35, 0)
+	})
+	tween:Play()
+
+	task.wait(3)
+
+	local hideTween = TweenService:Create(winnerFrame, TweenInfo.new(0.5, Enum.EasingStyle.Back, Enum.EasingDirection.In), {
+		Position = UDim2.new(0.2, 0, 2, 0)
+	})
+	hideTween:Play()
+end
+
+local function showCountdown(number)
+	countdownText.Text = tostring(number)
+	countdownFrame.Position = UDim2.new(0.35, 0, 0.35, 0)
+	countdownFrame.Size = UDim2.new(0.3, 0, 0.3, 0)
+
+	local tween = TweenService:Create(countdownFrame, TweenInfo.new(1, Enum.EasingStyle.Linear), {
+		Size = UDim2.new(0.4, 0, 0.4, 0),
+		BackgroundTransparency = 1
+	})
+
+	local textTween = TweenService:Create(countdownText, TweenInfo.new(1, Enum.EasingStyle.Linear), {
+		TextTransparency = 1
+	})
+
+	tween:Play()
+	textTween:Play()
+
+	tween.Completed:Connect(function()
+		countdownFrame.Position = UDim2.new(0.35, 0, 2, 0)
+		countdownFrame.BackgroundTransparency = 0.5
+		countdownText.TextTransparency = 0
+	end)
+end
+
+-- Handle state changes
+stateChangeRemote.OnClientEvent:Connect(function(state, message)
+	statusText.Text = message or state
+
+	-- Handle different states with refined colors
+	if state == "WAITING" then
+		statusText.TextColor3 = Color3.fromRGB(180, 180, 190)
+		timerText.Text = ""
+	elseif state == "INTERMISSION" then
+		statusText.TextColor3 = Color3.fromRGB(255, 220, 80)
+	elseif state == "STARTING" then
+		statusText.TextColor3 = Color3.fromRGB(90, 220, 255)
+		-- Show countdown if it's a number
+		local num = tonumber(string.match(message or "", "%d+"))
+		if num and num <= 3 then
+			showCountdown(num)
+		end
+	elseif state == "IN_PROGRESS" then
+		statusText.TextColor3 = Color3.fromRGB(80, 255, 200)
+		timerText.Text = ""
+		if message == "GO!" then
+			showCountdown("GO!")
+		end
+	elseif state == "ENDING" then
+		statusText.TextColor3 = Color3.fromRGB(255, 160, 90)
+		timerText.Text = ""
+		if message and message:find("wins!") then
+			showWinner(message)
+		end
+	end
+end)
+
+-- Handle timer updates with phase-aware progress bar
+timerRemote.OnClientEvent:Connect(function(timeLeft, totalTime, phase)
+	if totalTime and timeLeft and timeLeft >= 0 then
+		-- Show a phase-aware progress bar
+		progressBack.Visible = true
+
+		-- Fill grows from 0 -> 1 as time counts down
+		local ratio = math.clamp(1 - (timeLeft / totalTime), 0, 1)
+		progressFill.Size = UDim2.new(ratio, 0, 1, 0)
+
+		-- Update timer text and accent color by phase
+		if phase == "INTERMISSION" then
+			timerText.TextColor3 = Color3.fromRGB(255, 200, 0)
+			statusText.Text = "Intermission"
+		elseif phase == "FREEZE" then
+			timerText.TextColor3 = Color3.fromRGB(140, 200, 255)
+			statusText.Text = "Get Ready"
+		end
+
+		timerText.Text = "Time: " .. timeLeft .. "s"
+	else
+		-- Hide bar when no active phase timer
+		progressBack.Visible = false
+		progressFill.Size = UDim2.new(0, 0, 1, 0)
+		timerText.Text = ""
+	end
+end)
+
+print("[ROUND UI] Client UI initialized")
+


### PR DESCRIPTION
Improve round UI and gate map hazards to activate only after the pre-round freeze.

Previously, map hazards (rotating kill part, disappearing floors) could be active during the initial freeze period of a round. This change introduces a server-side `HazardsEnabled` flag to synchronize these hazards with the round state, ensuring they only activate after the freeze and are disabled during intermission/round end. The UI was also enhanced with a progress bar and clearer state colors for better player feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-22075d83-fc86-42f8-a4a6-51c41db4f524">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22075d83-fc86-42f8-a4a6-51c41db4f524">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

